### PR TITLE
fix(stretched-covers): fix max_img_w/max_img_h

### DIFF
--- a/2---stretched-covers.lua
+++ b/2---stretched-covers.lua
@@ -11,17 +11,19 @@ local fill = false                  -- if true, covers will fit the full grid ce
 
 local ImageWidget = require("ui/widget/imagewidget")
 local Size = require("ui/size")
+local logger = require("logger")
 local userpatch = require("userpatch")
 
 local function patchBookCoverRoundedCorners(plugin)
     local MosaicMenu = require("mosaicmenu")
     local MosaicMenuItem = userpatch.getUpValue(MosaicMenu._updateItemsBuildUI, "MosaicMenuItem")
-	
+
     if MosaicMenuItem.patched_stretched_covers then
         return
     end
     MosaicMenuItem.patched_stretched_covers = true
-	
+
+    -- Find the local ImageWidget in the closure
     local local_ImageWidget
     local n = 1
     while true do
@@ -34,91 +36,71 @@ local function patchBookCoverRoundedCorners(plugin)
             break
         end
         n = n + 1
-    end    
+    end
+
     if not local_ImageWidget then
+        logger.warn("Could not find ImageWidget in MosaicMenuItem.update closure")
         return
-    end  
+    end
+
     local setupvalue_n = n
-	
-    -- Store instance-specific data
-    local instance_data = {}   
+
     -- Get the original init method
-    local orig_MosaicMenuItem_init = MosaicMenuItem.init    
+    local orig_MosaicMenuItem_init = MosaicMenuItem.init
+    local max_img_w, max_img_h
+
     -- Override init to store dimensions per instance
-    MosaicMenuItem.init = function(self)
-        -- Generate a unique ID for this instance
-        local instance_id = tostring(self):match("0x(%x+)") or tostring(self)        
+    function MosaicMenuItem:init()
         if self.width and self.height then
             -- Store dimensions for this specific instance
             local border_size = Size.border.thin
-            local underline_h = 1  -- Default from original code            
+
             -- Calculate available space for the image
-            instance_data[instance_id] = {
-                max_img_w = self.width - 2 * border_size,     -- Available width inside border
-                max_img_h = self.height - 2 * border_size,    -- Available height inside border
-                border_size = border_size,
-                underline_h = underline_h,
-                cell_width = self.width,
-                cell_height = self.height
-            }
-        end       
-		
+            max_img_w = self.width - 2 * border_size -- Available width inside border
+            max_img_h = self.height - 2 * border_size -- Available height inside border
+        end
+
         -- Call original init
         if orig_MosaicMenuItem_init then
             orig_MosaicMenuItem_init(self)
         end
     end
-	
+
     -- Create custom ImageWidget subclass
-    local StretchingImageWidget = local_ImageWidget:extend({})    
+    local StretchingImageWidget = local_ImageWidget:extend({})
+
     StretchingImageWidget.init = function(self)
-        -- Get instance ID
-        local instance_id = nil
-        local parent = self.parent
-        while parent do
-            local parent_id = tostring(parent):match("0x(%x+)")
-            if parent_id and instance_data[parent_id] then
-                instance_id = parent_id
-                break
-            end
-            parent = parent.parent
-        end        
-        if not instance_id then
-            -- Fallback: try to find any instance data
-            for id, _ in pairs(instance_data) do
-                instance_id = id
-                break
-            end
-        end   
-		
-        if instance_id and instance_data[instance_id] then
-            local data = instance_data[instance_id]
-            local max_img_w = data.max_img_w
-            local max_img_h = data.max_img_h            
-            -- Reset scale factor
-            self.scale_factor = nil            
-            -- Set stretch limit
-            self.stretch_limit_percentage = stretch_limit_percentage            
-            -- Calculate dimensions based on aspect ratio
-            local ratio = fill and (max_img_w / max_img_h) or aspect_ratio            
-            if max_img_w / max_img_h > ratio then
-                -- Cell is wider than target ratio - use full height
-                self.height = max_img_h
-                self.width = max_img_h * ratio
-            else
-                -- Cell is taller than target ratio - use full width
-                self.width = max_img_w
-                self.height = max_img_w / ratio
-            end
-        end     
-		
         -- Call original ImageWidget init if it exists
         if local_ImageWidget.init then
             local_ImageWidget.init(self)
         end
+        if not max_img_w and not max_img_h then
+            -- As above, do nothing if we were not able to compute them
+            return
+        end
+        -- Reset scale factor
+        self.scale_factor = nil
+
+        -- Set stretch limit
+        self.stretch_limit_percentage = stretch_limit
+
+        -- Calculate dimensions based on aspect ratio
+        local ratio = Fill and (max_img_w / max_img_h) or aspect_ratio
+
+        if max_img_w / max_img_h > ratio then
+            -- Cell is wider than target ratio - use full height
+            self.height = max_img_h
+            self.width = max_img_h * ratio
+        else
+            -- Cell is taller than target ratio - use full width
+            self.width = max_img_w
+            self.height = max_img_w / ratio
+        end
     end
-	
+
     -- Replace the local ImageWidget with our custom one
     debug.setupvalue(MosaicMenuItem.update, setupvalue_n, StretchingImageWidget)
+
+    logger.info("Aspect ratio control applied successfully")
 end
 userpatch.registerPatchPluginFunc("coverbrowser", patchBookCoverRoundedCorners)


### PR DESCRIPTION
Hi,

I noticed you added a whole thing with `instance_data` to get the max cell height/width, but that had multiple problems:

* that cache would grow indefinitely, resulting again in growing memory and eventually in slowdowns when just browsing the file explorer
* it also didn't work properly for me in both the emulator and on my Kobo. In portrait mode it looked OK on my Kobo, but in landscape mode the covers were too small. (see screenshots)

The code as it was looked a little funny since it was setting/reading two vars in the scope of the whole patch, but this is actually completely correct :)

If you'd look at the koreader code, you'll see that the code path for creating a menu item will first create a new `MosaicMenuItem`, which will set the `max_` vars and right after that it will call `update`, so those vars are exactly those that we need. So there's simply no need for any more advanced juggling with what you were doing with `instance_data`. That's btw also why we literally update the upvalue inside that `update` method:

```lua
-- Replace the local ImageWidget with our custom one
debug.setupvalue(MosaicMenuItem.update, setupvalue_n, StretchingImageWidget)
```

This PR fixes this.

# Screenshots

With your changes
<img width="2010" height="1131" alt="image" src="https://github.com/user-attachments/assets/e9964c57-fa83-4429-a513-0e126c13e17b" />

With this PR:
<img width="2010" height="1131" alt="image" src="https://github.com/user-attachments/assets/acbabb28-b234-4439-82d4-4fb3136ac3c5" />

 