### PR TITLE
Update patches for Project: Title 3.8+ plugin name change

### DIFF
--- a/2---stretched-covers.lua
+++ b/2---stretched-covers.lua
@@ -103,4 +103,4 @@ local function patchBookCoverRoundedCorners(plugin)
 
     logger.info("Aspect ratio control applied successfully")
 end
-userpatch.registerPatchPluginFunc("coverbrowser", patchBookCoverRoundedCorners)
+userpatch.registerPatchPluginFunc("projecttitle", patchBookCoverRoundedCorners)

--- a/2--disable-all-CB-widgets.lua
+++ b/2--disable-all-CB-widgets.lua
@@ -57,4 +57,4 @@ local function patchDisableUIElements(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchDisableUIElements)
+userpatch.registerPatchPluginFunc("projecttitle", patchDisableUIElements)

--- a/2--disable-all-CB-widgets.lua
+++ b/2--disable-all-CB-widgets.lua
@@ -57,4 +57,4 @@ local function patchDisableUIElements(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("projecttitle", patchDisableUIElements)
+userpatch.registerPatchPluginFunc("coverbrowser", patchDisableUIElements)

--- a/2--disable-all-PT-widgets.lua
+++ b/2--disable-all-PT-widgets.lua
@@ -131,4 +131,4 @@ local function patchDisableUIElements(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchDisableUIElements)
+userpatch.registerPatchPluginFunc("projecttitle", patchDisableUIElements)

--- a/2--rounded-covers.lua
+++ b/2--rounded-covers.lua
@@ -122,4 +122,4 @@ local function patchBookCoverRoundedCorners(plugin)
         end
     end
 end
-userpatch.registerPatchPluginFunc("coverbrowser", patchBookCoverRoundedCorners)
+userpatch.registerPatchPluginFunc("projecttitle", patchBookCoverRoundedCorners)

--- a/2--stretched-rounded-covers.lua
+++ b/2--stretched-rounded-covers.lua
@@ -218,4 +218,4 @@ local function patchAspectRatioWithRoundedCorners(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchAspectRatioWithRoundedCorners)
+userpatch.registerPatchPluginFunc("projecttitle", patchAspectRatioWithRoundedCorners)

--- a/2-new-collections-star.lua
+++ b/2-new-collections-star.lua
@@ -62,4 +62,4 @@ local function patchCoverBrowserCollectionIndicator(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchCoverBrowserCollectionIndicator)
+userpatch.registerPatchPluginFunc("projecttitle", patchCoverBrowserCollectionIndicator)

--- a/2-new-progress-bar-colored.lua
+++ b/2-new-progress-bar-colored.lua
@@ -126,4 +126,4 @@ local function patchCustomProgress(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchCustomProgress)
+userpatch.registerPatchPluginFunc("projecttitle", patchCustomProgress)

--- a/2-new-progress-bar.lua
+++ b/2-new-progress-bar.lua
@@ -105,4 +105,4 @@ local function patchCustomProgress(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchCustomProgress)
+userpatch.registerPatchPluginFunc("projecttitle", patchCustomProgress)

--- a/2-new-status-icons.lua
+++ b/2-new-status-icons.lua
@@ -113,4 +113,4 @@ local function patchCoverBrowserStatusIcons(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchCoverBrowserStatusIcons)
+userpatch.registerPatchPluginFunc("projecttitle", patchCoverBrowserStatusIcons)

--- a/2-pages-badge.lua
+++ b/2-pages-badge.lua
@@ -108,4 +108,4 @@ local function patchCoverBrowserPageCount(plugin)
         end
     end
 end
-userpatch.registerPatchPluginFunc("coverbrowser", patchCoverBrowserPageCount)
+userpatch.registerPatchPluginFunc("projecttitle", patchCoverBrowserPageCount)

--- a/2-percent-badge.lua
+++ b/2-percent-badge.lua
@@ -105,4 +105,4 @@ local function patchCoverBrowserProgressPercent(plugin)
         end
     end
 end
-userpatch.registerPatchPluginFunc("coverbrowser", patchCoverBrowserProgressPercent)
+userpatch.registerPatchPluginFunc("projecttitle", patchCoverBrowserProgressPercent)

--- a/2-rounded-folder-covers.lua
+++ b/2-rounded-folder-covers.lua
@@ -489,4 +489,4 @@ local function patchCoverBrowser(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchCoverBrowser)
+userpatch.registerPatchPluginFunc("projecttitle", patchCoverBrowser)

--- a/2-series-badge-numbered.lua
+++ b/2-series-badge-numbered.lua
@@ -137,4 +137,4 @@ local function patchAddSeriesIndicator(plugin)
 	end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchAddSeriesIndicator)
+userpatch.registerPatchPluginFunc("projecttitle", patchAddSeriesIndicator)

--- a/2-series-indicator.lua
+++ b/2-series-indicator.lua
@@ -75,4 +75,4 @@ local function patchAddSeriesIndicator(plugin)
         end
     end
 end
-userpatch.registerPatchPluginFunc("coverbrowser", patchAddSeriesIndicator)
+userpatch.registerPatchPluginFunc("projecttitle", patchAddSeriesIndicator)

--- a/20-faded-finished-books.lua
+++ b/20-faded-finished-books.lua
@@ -51,4 +51,4 @@ local function patchCoverBrowserFaded(plugin)
     end
 end
 
-userpatch.registerPatchPluginFunc("coverbrowser", patchCoverBrowserFaded)
+userpatch.registerPatchPluginFunc("projecttitle", patchCoverBrowserFaded)


### PR DESCRIPTION
For versions 3.8 and above, Project: Title changed the plugin name from
`coverbrowser` to `projecttitle`, as per:

https://github.com/joshuacant/ProjectTitle/wiki/User-Patches-for-Project-Title#updating-user-patches-to-work-with-pt-38-and-above

This PR updates all patches except `2--disable-all-CB-widgets.lua`, which is
left targeting `coverbrowser` since it's the CoverBrowser-specific counterpart
to `2--disable-all-PT-widgets.lua`.